### PR TITLE
Restore enterOnRotate option and add exitOnRotate

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ npm install --save videojs-mobile-ui
 {
   fullscreen: {
     enterOnRotate: true,
+    exitOnRotate, true,
     lockOnRotate: true
   },
   touchControls: {
@@ -57,6 +58,7 @@ npm install --save videojs-mobile-ui
 ### Options
 
 - *fullscreen.enterOnRotate* `boolean` Whether to go fullscreen when rotating to landscape
+- *fullscreen.exitOnRotate* `boolean` Whether to leave fullscreen when rotating to portrait (if not locked)
 - *fullscreen.lockOnRotate* `boolean` Whether to lock to fullscreen when rotating to landscape
 - *fullscreen.iOS* `boolean` Whether to use fake fullscreen on iOS (needed for controls to work)
 - *touchControls.seekSeconds* `int` Seconds to seek when double-tapping

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ npm install --save videojs-mobile-ui
 {
   fullscreen: {
     enterOnRotate: true,
-    exitOnRotate, true,
+    exitOnRotate: true,
     lockOnRotate: true
   },
   touchControls: {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -7,6 +7,7 @@ import window from 'global/window';
 const defaults = {
   fullscreen: {
     enterOnRotate: true,
+    exitOnRotate: true,
     lockOnRotate: true,
     iOS: false
   },
@@ -71,7 +72,7 @@ const onPlayerReady = (player, options) => {
   const rotationHandler = () => {
     const currentAngle = angle();
 
-    if (currentAngle === 90 || currentAngle === 270 || currentAngle === -90) {
+    if ((currentAngle === 90 || currentAngle === 270 || currentAngle === -90) && options.enterOnRotate) {
       if (player.paused() === false) {
         player.requestFullscreen();
         if (options.fullscreen.lockOnRotate &&
@@ -84,7 +85,8 @@ const onPlayerReady = (player, options) => {
         }
       }
     }
-    if (currentAngle === 0 || currentAngle === 180) {
+
+    if ((currentAngle === 0 || currentAngle === 180) && options.exitOnRotate) {
       if (player.isFullscreen()) {
         player.exitFullscreen();
       }
@@ -118,6 +120,8 @@ const onPlayerReady = (player, options) => {
  *           Fullscreen options.
  * @param    {boolean} [options.fullscreen.enterOnRotate=true]
  *           Whether to go fullscreen when rotating to landscape
+ * @param    {boolean} [options.fullscreen.exitOnRotate=true]
+ *           Whether to leave fullscreen when rotating to portrait (if not locked)
  * @param    {boolean} [options.fullscreen.lockOnRotate=true]
  *           Whether to lock orientation when rotating to landscape
  *           Unlocked when exiting fullscreen or on 'ended'


### PR DESCRIPTION
Restores `enterOnRotate` as an option as documented.
Adds `exitOnRotate` to make that behaviour optional.

Fixes #4 