### PR TITLE
fix: Use component index for newer vjs and element index for old

### DIFF
--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -38,11 +38,23 @@ QUnit.module('videojs-mobile-ui', {
 });
 
 QUnit.test('registers itself with video.js', function(assert) {
-  // assert.expect(2);
 
   assert.strictEqual(
     typeof Player.prototype.mobileUi,
     'function',
     'videojs-mobile-ui plugin was registered'
+  );
+});
+
+QUnit.test('inserts element before control bar', function(assert) {
+
+  this.player.mobileUi({forceForTesting: true});
+
+  this.clock.tick(1);
+
+  assert.strictEqual(
+    this.player.getChild('TouchOverlay').el_.nextSibling,
+    this.player.getChild('ControlBar').el_,
+    'TouchOverlay is before ControlBar'
   );
 });


### PR DESCRIPTION
A workaround for an old bad behaviour of `addChild` is problematic on newer versions of v7 where that has been fixed, resulting in the overlay being placed topmost.

Now does a version check, and inserts the component at the index of the control bar element in Video.js < 7.7.0 (a better workaround than the previous one) and at the index of the control bar component in later versions.

Also adds a `forceForTesting` option to enable when not on mobile, to run tests. As the name implies it's not intended for real world usage.

Fixes #8 