### PR TITLE
fix: Detect angle correctly where no window.orientation

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,26 +17,96 @@
   </style>
 </head>
 <body>
-  <video id="videojs-mobile-ui-player" class="video-js vjs-default-skin" controls>
+  <video-js id="videojs-mobile-ui-player" class="video-js vjs-default-skin" controls playsinline>
     <source src="//vjs.zencdn.net/v/oceans.mp4" type='video/mp4'>
     <source src="//vjs.zencdn.net/v/oceans.webm" type='video/webm'>
-  </video>
+  </video-js>
   <ul>
     <li><a href="test/">Run unit tests in browser.</a></li>
     <li><a href="docs/api/">Read generated docs.</a></li>
   </ul>
-
+  <h2>Options</h2>
+  <ul id="options">
+    <li>fullscreen:</li>
+    <ul>
+      <li><input type="checkbox"  data-section="fullscreen" id="enterOnRotate">enterOnRotate</li>
+      <li><input type="checkbox" data-section="fullscreen" id="exitOnRotate">exitOnRotate</li>
+      <li><input type="checkbox" data-section="fullscreen" id="lockOnRotate">lockOnRotate</li>
+      <li><input type="checkbox" data-section="fullscreen" id="iOS">iOS</li>
+    </ul>
+    <li>touchControls:</li>
+    <ul>
+      <li><input type="number" data-section="touchControls" id="seekSeconds">seekSeconds</li>
+      <li><input type="number" data-section="touchControls" id="tapTimeout">tapTimeout</li>
+      <li><input type="checkbox" data-section="touchControls" id="disableOnEnd">disableOnEnd</li>
+    </ul>
+  </ul>
+  <button id="reload">Reload with options</button>
+  <ul id="log"></ul>
   <script src="node_modules/video.js/dist/video.js"></script>
   <script src="dist/videojs-mobile-ui.js"></script>
   <script>
     (function(window, videojs) {
+      var options = {
+        fullscreen: {
+          enterOnRotate: true,
+          exitOnRotate: true,
+          lockOnRotate: true,
+          iOS: false
+        },
+        touchControls: {
+          seekSeconds: 10,
+          tapTimeout: 300,
+          disableOnEnd: false
+        }
+      };
+      var url = new URL(window.location);
+      if (url.searchParams.has('options')) {
+        options = JSON.parse(url.searchParams.get('options'));
+      }
+
+      Object.keys(options).forEach(function(section) {
+        Object.keys(options[section]).forEach(function(prop) {
+          const val = options[section][prop];
+
+          if (typeof val === 'boolean') {
+            document.getElementById(prop).checked = val; 
+          }
+          if (typeof val === 'number') {
+            document.getElementById(prop).value = val; 
+          }
+        });
+      });
+
+      document.getElementById('options').querySelectorAll('input').forEach(function(opt) {
+        opt.addEventListener('change', function() {
+          if (this.type === 'checkbox') {
+            options[this.getAttribute('data-section')][this.id] = this.checked;
+          } else {
+            options[this.getAttribute('data-section')][this.id] = parseFloat(this.value);
+          }
+          console.log(options);
+        });
+      });
+
+      document.getElementById('reload').addEventListener('click', function() {
+        url.searchParams.set('options', JSON.stringify(options));
+
+        window.location = url.href;
+      })
+
+      window.addEventListener('orientationchange', function() {
+        var el = document.createElement('li');
+        var message = (new Date).toTimeString().split(' ')[0] + ' ' + window.orientation;
+        message += (screen && screen.orientation ? ' ' + screen.orientation.type + ' ' + screen.orientation.angle : '');
+        el.textContent = message;
+        console.log(message);
+        document.getElementById('log').appendChild(el);
+      });
+
       var testPlayer = window.testPlayer = videojs('videojs-mobile-ui-player');
       testPlayer.endscreen = function() {};
-      testPlayer.mobileUi({
-        fullscreen: {
-          iOS: true
-        }
-      });
+      testPlayer.mobileUi(options);
     }(window, window.videojs));
   </script>
 </body>

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -25,9 +25,25 @@ const angle = () => {
   if (typeof window.orientation === 'number') {
     return window.orientation;
   }
-  // Android also supports screen.orientation. Some tablets may only support screen.orientation?
-  if (screen && screen.orientation && screen.orientation.angle) {
-    return window.orientation.angle;
+  // Android also supports screen.orientation
+  if (screen) {
+    if (screen.orientation && typeof screen.orientation.angle === 'number') {
+      return window.orientation.angle;
+    }
+
+    // Some tablets may only support screen.orientation.type ?
+    const orientationType = (screen.orientation || {}).type || screen.mozOrientation || screen.msOrientation;
+
+    if (orientationType === 'string') {
+      const type = orientationType.split('-')[0];
+
+      if (type === 'portrait') {
+        return 0;
+      }
+      if (type === 'landscape') {
+        return 90;
+      }
+    }
   }
   videojs.log('angle unknown');
   return 0;

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -21,13 +21,13 @@ const defaults = {
 const screen = window.screen;
 
 const angle = () => {
-  // iOS
+  // iOS only supports window.orientation
   if (typeof window.orientation === 'number') {
     return window.orientation;
   }
-  // Android
+  // Android also supports screen.orientation. Some tablets may only support screen.orientation?
   if (screen && screen.orientation && screen.orientation.angle) {
-    return window.orientation;
+    return window.orientation.angle;
   }
   videojs.log('angle unknown');
   return 0;


### PR DESCRIPTION
`currentAngle` should return `screen.orientation.angle` rather than `screen.orientation`. Not caught before as Andorid browsers generally support `window.orientation`, which is the only thing iOS supports, but apparently some tablets don't so this bug surfaced. 

Fixes #15