### PR TITLE
feat: Add disable options

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>videojs-mobile-ui Demo</title>
   <link href="node_modules/video.js/dist/video-js.css" rel="stylesheet">
   <link href="dist/videojs-mobile-ui.css" rel="stylesheet">
@@ -17,7 +18,7 @@
   </style>
 </head>
 <body>
-  <video-js id="videojs-mobile-ui-player" class="video-js vjs-default-skin" controls playsinline>
+  <video-js id="videojs-mobile-ui-player" class="video-js vjs-default-skin vjs-fluid" controls playsinline>
     <source src="//vjs.zencdn.net/v/oceans.mp4" type='video/mp4'>
     <source src="//vjs.zencdn.net/v/oceans.webm" type='video/webm'>
   </video-js>
@@ -32,13 +33,15 @@
       <li><input type="checkbox"  data-section="fullscreen" id="enterOnRotate">enterOnRotate</li>
       <li><input type="checkbox" data-section="fullscreen" id="exitOnRotate">exitOnRotate</li>
       <li><input type="checkbox" data-section="fullscreen" id="lockOnRotate">lockOnRotate</li>
-      <li><input type="checkbox" data-section="fullscreen" id="iOS">iOS</li>
+      <li><input type="checkbox" data-section="fullscreen" id="iOS">iOS <b>Deprecated</b></li>
+      <li><input type="checkbox" data-section="fullscreen" id="fullscreenDisabled">disabled</li>
     </ul>
     <li>touchControls:</li>
     <ul>
       <li><input type="number" data-section="touchControls" id="seekSeconds">seekSeconds</li>
       <li><input type="number" data-section="touchControls" id="tapTimeout">tapTimeout</li>
       <li><input type="checkbox" data-section="touchControls" id="disableOnEnd">disableOnEnd</li>
+      <li><input type="checkbox" data-section="touchControls" id="touchControlsDisabled">disabled</li>
     </ul>
   </ul>
   <button id="reload">Reload with options</button>
@@ -52,22 +55,31 @@
           enterOnRotate: true,
           exitOnRotate: true,
           lockOnRotate: true,
-          iOS: false
+          iOS: false,
+          disabled: false
         },
         touchControls: {
           seekSeconds: 10,
           tapTimeout: 300,
-          disableOnEnd: false
+          disableOnEnd: false,
+          disabled: false
         }
       };
+
       var url = new URL(window.location);
       if (url.searchParams.has('options')) {
         options = JSON.parse(url.searchParams.get('options'));
       }
 
+      console.log(JSON.stringify(options, null, 2));
+
       Object.keys(options).forEach(function(section) {
         Object.keys(options[section]).forEach(function(prop) {
           const val = options[section][prop];
+
+          if (prop === 'disabled') {
+            prop = `${section}Disabled`;
+          }
 
           if (typeof val === 'boolean') {
             document.getElementById(prop).checked = val; 
@@ -81,7 +93,9 @@
       document.getElementById('options').querySelectorAll('input').forEach(function(opt) {
         opt.addEventListener('change', function() {
           if (this.type === 'checkbox') {
-            options[this.getAttribute('data-section')][this.id] = this.checked;
+            const param = this.id.endsWith('Disabled') ? 'disabled' : this.id;
+
+            options[this.getAttribute('data-section')][param] = this.checked;
           } else {
             options[this.getAttribute('data-section')][this.id] = parseFloat(this.value);
           }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -9,12 +9,14 @@ const defaults = {
     enterOnRotate: true,
     exitOnRotate: true,
     lockOnRotate: true,
-    iOS: false
+    iOS: false,
+    disabled: false
   },
   touchControls: {
     seekSeconds: 10,
     tapTimeout: 300,
-    disableOnEnd: false
+    disableOnEnd: false,
+    disabled: false
   }
 };
 
@@ -60,38 +62,47 @@ const registerPlugin = videojs.registerPlugin || videojs.plugin;
  *           A plain object containing options for the plugin.
  */
 const onPlayerReady = (player, options) => {
-  player.addClass ('vjs-mobile-ui');
+  player.addClass('vjs-mobile-ui');
 
-  if (options.touchControls.disableOnEnd || typeof player.endscreen === 'function') {
-    player.addClass ('vjs-mobile-ui-disable-end');
+  if (options.fullscreen.iOS) {
+    videojs.log.warn('videojs-mobile-ui: `fullscreen.iOS` is deprecated. Use Video.js option `preferFullWindow` instead.');
+    if (videojs.browser.IS_IOS && videojs.browser.IOS_VERSION > 9 &&
+        !player.el_.ownerDocument.querySelector('.bc-iframe')) {
+      player.tech_.el_.setAttribute('playsinline', 'playsinline');
+      player.tech_.supportsFullScreen = function() {
+        return false;
+      };
+    }
   }
 
-  if (options.fullscreen.iOS &&
-      videojs.browser.IS_IOS && videojs.browser.IOS_VERSION > 9 &&
-      !player.el_.ownerDocument.querySelector('.bc-iframe')) {
-    player.tech_.el_.setAttribute('playsinline', 'playsinline');
-    player.tech_.supportsFullScreen = function() {
-      return false;
-    };
+  if (!options.touchControls.disabled) {
+
+    if (options.touchControls.disableOnEnd || typeof player.endscreen === 'function') {
+      player.addClass('vjs-mobile-ui-disable-end');
+    }
+
+    // Insert before the control bar
+    let controlBarIdx;
+    const versionParts = videojs.VERSION.split('.');
+    const major = parseInt(versionParts[0], 10);
+    const minor = parseInt(versionParts[1], 10);
+
+    // Video.js < 7.7.0 doesn't account for precedding components that don't have elements
+    if (major < 7 || (major === 7 && minor < 7)) {
+      controlBarIdx = Array.prototype.indexOf.call(
+        player.el_.children,
+        player.getChild('ControlBar').el_
+      );
+    } else {
+      controlBarIdx = player.children_.indexOf(player.getChild('ControlBar'));
+    }
+
+    player.touchOverlay = player.addChild('TouchOverlay', options.touchControls, controlBarIdx);
   }
 
-  // Insert before the control bar
-  let controlBarIdx;
-  const versionParts = videojs.VERSION.split('.');
-  const major = parseInt(versionParts[0], 10);
-  const minor = parseInt(versionParts[1], 10);
-
-  // Video.js < 7.7.0 doesn't account for precedding components that don't have elements
-  if (major < 7 || (major === 7 && minor < 7)) {
-    controlBarIdx = Array.prototype.indexOf.call(
-      player.el_.children,
-      player.getChild('ControlBar').el_
-    );
-  } else {
-    controlBarIdx = player.children_.indexOf(player.getChild('ControlBar'));
+  if (options.fullscreen.disabled) {
+    return;
   }
-
-  player.addChild('TouchOverlay', options.touchControls, controlBarIdx);
 
   let locked = false;
 
@@ -132,17 +143,17 @@ const onPlayerReady = (player, options) => {
         screen.orientation.onchange = null;
       });
     }
+
+    player.on('fullscreenchange', _ => {
+      if (!player.isFullscreen() && locked) {
+        screen.orientation.unlock();
+        locked = false;
+      }
+    });
   }
 
   player.on('ended', _ => {
     if (locked === true) {
-      screen.orientation.unlock();
-      locked = false;
-    }
-  });
-
-  player.on('fullscreenchange', _ => {
-    if (!player.isFullscreen() && locked) {
       screen.orientation.unlock();
       locked = false;
     }
@@ -161,6 +172,8 @@ const onPlayerReady = (player, options) => {
  *           Enables the display regardless of user agent, for testing purposes
  * @param    {Object} [options.fullscreen={}]
  *           Fullscreen options.
+ * @param    {boolean} [options.fullscreen.disabled=false]
+ *           If true no fullscreen handling except the *deprecated* iOS fullwindow hack
  * @param    {boolean} [options.fullscreen.enterOnRotate=true]
  *           Whether to go fullscreen when rotating to landscape
  * @param    {boolean} [options.fullscreen.exitOnRotate=true]
@@ -169,9 +182,11 @@ const onPlayerReady = (player, options) => {
  *           Whether to lock orientation when rotating to landscape
  *           Unlocked when exiting fullscreen or on 'ended'
  * @param    {boolean} [options.fullscreen.iOS=false]
- *           Whether to disable iOS's native fullscreen so controls can work
+ *           Deprecated: Whether to disable iOS's native fullscreen so controls can work
  * @param    {Object} [options.touchControls={}]
  *           Touch UI options.
+ * @param    {boolean} [options.touchControls.disabled=false]
+ *           If true no touch controls are added.
  * @param    {int} [options.touchControls.seekSeconds=10]
  *           Number of seconds to seek on double-tap
  * @param    {int} [options.touchControls.tapTimeout=300]

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -62,6 +62,24 @@ QUnit.test('inserts element before control bar', function(assert) {
   );
 });
 
+QUnit.test('does not insert if disabled', function(assert) {
+
+  this.player.mobileUi({
+    forceForTesting: true,
+    touchControls: {
+      disabled: true
+    }
+  });
+
+  this.clock.tick(1);
+
+  assert.strictEqual(
+    this.player.touchOverlay,
+    undefined,
+    'TouchOverlay should not be present'
+  );
+});
+
 QUnit.test('iOS event listeners', function(assert) {
 
   const oldBrowser = videojs.browser;
@@ -118,7 +136,7 @@ QUnit[testOrSkip]('Android event listeners', function(assert) {
   assert.strictEqual(
     typeof window.screen.orientation.onchange,
     'function',
-    'screen.orientation.onchange is used for andorid'
+    'screen.orientation.onchange is used for android'
   );
 
   this.player.dispose();
@@ -129,6 +147,33 @@ QUnit[testOrSkip]('Android event listeners', function(assert) {
     window.screen.orientation.onchange,
     null,
     'screen.orientation.onchange is removed after dispose'
+  );
+
+  videojs.browser = oldBrowser;
+});
+
+QUnit[testOrSkip]('Android event listeners skipped if disabled', function(assert) {
+
+  const oldBrowser = videojs.browser;
+
+  videojs.browser = videojs.mergeOptions(videojs.browser, {
+    IS_IOS: false,
+    IS_ANDROID: true
+  });
+
+  this.player.mobileUi({
+    forceForTesting: true,
+    fullscreen: {
+      disabled: true
+    }
+  });
+
+  this.clock.tick(1);
+
+  assert.notStrictEqual(
+    typeof window.screen.orientation.onchange,
+    'function',
+    'screen.orientation.onchange skipped for android'
   );
 
   videojs.browser = oldBrowser;


### PR DESCRIPTION
* Adds options `fullscreen.disabled` and `touchControls.disabled` to disable full screen and the controls respectively.
* Deprecates `fullscreen.iOS` as there is now a standard Video.js option [`preferFullWindow`](https://github.com/videojs/video.js/blob/main/docs/guides/options.md#preferfullwindow).


Fixes #30 