### PR TITLE
feat: Add option to lock to landscape when entering fullscreen

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ npm install --save videojs-mobile-ui
     enterOnRotate: true,
     exitOnRotate: true,
     lockOnRotate: true,
-    alwaysLockToLandscape: false,
+    lockToLandscapeOnEnter: false,
     iOS: false,
     disabled: false
   },
@@ -65,7 +65,7 @@ npm install --save videojs-mobile-ui
 - *fullscreen.enterOnRotate* `boolean` Whether to go fullscreen when rotating to landscape
 - *fullscreen.exitOnRotate* `boolean` Whether to leave fullscreen when rotating to portrait (if not locked)
 - *fullscreen.lockOnRotate* `boolean` Whether to lock to fullscreen when rotating to landscape
-- *fullscreen.alwaysLockToLandscape* `boolean` Whether to always lock fullscreen to landscape (works even when device rotation is disabled/non-functional)
+- *fullscreen.lockToLandscapeOnEnter* `boolean` Whether to lock to landscape when entering fullscreen (works even when device rotation is disabled/non-functional)
 - *fullscreen.iOS* `boolean` Whether to use fake fullscreen on iOS (needed for controls to work)
 - *fullscreen.disabled* `boolean` If true no fullscreen handling except the *deprecated* iOS fullwindow hack
 - *touchControls.seekSeconds* `int` Seconds to seek when double-tapping

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Fullscreen control:
 
 - Rotate to landscape to enter Fullscreen
 - Lock to fullscreen on rotate
-- Always lock fullscreen to landscape (works even when device rotation is disabled/non-functional)
+- Always lock to landscape when entering fullscreen (works even when device rotation is disabled/non-functional)
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Fullscreen control:
 
 - Rotate to landscape to enter Fullscreen
 - Lock to fullscreen on rotate
+- Always lock fullscreen to landscape (works even when device rotation is disabled/non-functional)
 
 ## Table of Contents
 
@@ -45,12 +46,16 @@ npm install --save videojs-mobile-ui
   fullscreen: {
     enterOnRotate: true,
     exitOnRotate: true,
-    lockOnRotate: true
+    lockOnRotate: true,
+    alwaysLockToLandscape: false,
+    iOS: false,
+    disabled: false
   },
   touchControls: {
     seekSeconds: 10,
     tapTimeout: 300,
-    disableOnEnd: false
+    disableOnEnd: false,
+    disabled: false,
   }
 };
 ```
@@ -60,10 +65,13 @@ npm install --save videojs-mobile-ui
 - *fullscreen.enterOnRotate* `boolean` Whether to go fullscreen when rotating to landscape
 - *fullscreen.exitOnRotate* `boolean` Whether to leave fullscreen when rotating to portrait (if not locked)
 - *fullscreen.lockOnRotate* `boolean` Whether to lock to fullscreen when rotating to landscape
+- *fullscreen.alwaysLockToLandscape* `boolean` Whether to always lock fullscreen to landscape (works even when device rotation is disabled/non-functional)
 - *fullscreen.iOS* `boolean` Whether to use fake fullscreen on iOS (needed for controls to work)
+- *fullscreen.disabled* `boolean` If true no fullscreen handling except the *deprecated* iOS fullwindow hack
 - *touchControls.seekSeconds* `int` Seconds to seek when double-tapping
 - *touchControls.tapTimeout* `int` Milliseconds to consider a double-tap
 - *touchControls.disableOnEnd* `boolean` Whether to disable touch controls when the video has ended, e.g. if an endscreen is used. Automatically disables if the endscreen plugin is present when this plugin initialises
+- *touchControls.disableOnEnd* `boolean` If true no touch controls are added.
 
 ## Usage
 

--- a/index.html
+++ b/index.html
@@ -1,127 +1,206 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
 <head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>videojs-mobile-ui Demo</title>
-  <link href="node_modules/video.js/dist/video-js.css" rel="stylesheet">
-  <link href="dist/videojs-mobile-ui.css" rel="stylesheet">
+  <link href="node_modules/video.js/dist/video-js.css" rel="stylesheet" />
+  <link href="dist/videojs-mobile-ui.css" rel="stylesheet" />
   <style>
-  .testEl {
-    width: 10%;
-    height: 10%;
-    position: absolute;
-    top: 0;
-    pointer-events: none;
-    display: none;
-  }
+    .testEl {
+      width: 10%;
+      height: 10%;
+      position: absolute;
+      top: 0;
+      pointer-events: none;
+      display: none;
+    }
   </style>
 </head>
 <body>
-  <video-js id="videojs-mobile-ui-player" class="video-js vjs-default-skin vjs-fluid" controls playsinline>
-    <source src="//vjs.zencdn.net/v/oceans.mp4" type='video/mp4'>
-    <source src="//vjs.zencdn.net/v/oceans.webm" type='video/webm'>
-  </video-js>
+  <video-js
+  id="videojs-mobile-ui-player"
+  class="video-js vjs-default-skin vjs-fluid"
+  controls
+  playsinline
+  >
+  <source src="//vjs.zencdn.net/v/oceans.mp4" type="video/mp4" />
+  <source src="//vjs.zencdn.net/v/oceans.webm" type="video/webm" />
+</video-js>
+<ul>
+  <li><a href="test/">Run unit tests in browser.</a></li>
+  <li><a href="docs/api/">Read generated docs.</a></li>
+</ul>
+<h2>Options</h2>
+<ul id="options">
+  <li>fullscreen:</li>
   <ul>
-    <li><a href="test/">Run unit tests in browser.</a></li>
-    <li><a href="docs/api/">Read generated docs.</a></li>
+    <li>
+      <input
+      type="checkbox"
+      data-section="fullscreen"
+      id="enterOnRotate"
+      />enterOnRotate
+    </li>
+    <li>
+      <input
+      type="checkbox"
+      data-section="fullscreen"
+      id="exitOnRotate"
+      />exitOnRotate
+    </li>
+    <li>
+      <input
+      type="checkbox"
+      data-section="fullscreen"
+      id="lockOnRotate"
+      />lockOnRotate
+    </li>
+    <li>
+      <input
+      type="checkbox"
+      data-section="fullscreen"
+      id="alwaysLockToLandscape"
+      />alwaysLockToLandscape
+    </li>
+    <li>
+      <input type="checkbox" data-section="fullscreen" id="iOS" />iOS
+      <b>Deprecated</b>
+    </li>
+    <li>
+      <input
+      type="checkbox"
+      data-section="fullscreen"
+      id="fullscreenDisabled"
+      />disabled
+    </li>
   </ul>
-  <h2>Options</h2>
-  <ul id="options">
-    <li>fullscreen:</li>
-    <ul>
-      <li><input type="checkbox"  data-section="fullscreen" id="enterOnRotate">enterOnRotate</li>
-      <li><input type="checkbox" data-section="fullscreen" id="exitOnRotate">exitOnRotate</li>
-      <li><input type="checkbox" data-section="fullscreen" id="lockOnRotate">lockOnRotate</li>
-      <li><input type="checkbox" data-section="fullscreen" id="iOS">iOS <b>Deprecated</b></li>
-      <li><input type="checkbox" data-section="fullscreen" id="fullscreenDisabled">disabled</li>
-    </ul>
-    <li>touchControls:</li>
-    <ul>
-      <li><input type="number" data-section="touchControls" id="seekSeconds">seekSeconds</li>
-      <li><input type="number" data-section="touchControls" id="tapTimeout">tapTimeout</li>
-      <li><input type="checkbox" data-section="touchControls" id="disableOnEnd">disableOnEnd</li>
-      <li><input type="checkbox" data-section="touchControls" id="touchControlsDisabled">disabled</li>
-    </ul>
+  <li>touchControls:</li>
+  <ul>
+    <li>
+      <input
+      type="number"
+      data-section="touchControls"
+      id="seekSeconds"
+      />seekSeconds
+    </li>
+    <li>
+      <input
+      type="number"
+      data-section="touchControls"
+      id="tapTimeout"
+      />tapTimeout
+    </li>
+    <li>
+      <input
+      type="checkbox"
+      data-section="touchControls"
+      id="disableOnEnd"
+      />disableOnEnd
+    </li>
+    <li>
+      <input
+      type="checkbox"
+      data-section="touchControls"
+      id="touchControlsDisabled"
+      />disabled
+    </li>
   </ul>
-  <button id="reload">Reload with options</button>
-  <ul id="log"></ul>
-  <script src="node_modules/video.js/dist/video.js"></script>
-  <script src="dist/videojs-mobile-ui.js"></script>
-  <script>
-    (function(window, videojs) {
-      var options = {
-        fullscreen: {
-          enterOnRotate: true,
-          exitOnRotate: true,
-          lockOnRotate: true,
-          iOS: false,
-          disabled: false
-        },
-        touchControls: {
-          seekSeconds: 10,
-          tapTimeout: 300,
-          disableOnEnd: false,
-          disabled: false
+</ul>
+<button id="reload">Reload with options</button>
+<ul id="log"></ul>
+<script src="node_modules/video.js/dist/video.js"></script>
+<script src="dist/videojs-mobile-ui.js"></script>
+<script>
+  (function (window, videojs) {
+    var options = {
+      fullscreen: {
+        enterOnRotate: true,
+        exitOnRotate: true,
+        lockOnRotate: true,
+        alwaysLockToLandscape: false,
+        iOS: false,
+        disabled: false,
+      },
+      touchControls: {
+        seekSeconds: 10,
+        tapTimeout: 300,
+        disableOnEnd: false,
+        disabled: false,
+      },
+    };
+
+    var url = new URL(window.location);
+    if (url.searchParams.has('options')) {
+      options = JSON.parse(url.searchParams.get('options'));
+    }
+
+    console.log(JSON.stringify(options, null, 2));
+
+    Object.keys(options).forEach(function (section) {
+      Object.keys(options[section]).forEach(function (prop) {
+        const val = options[section][prop];
+
+        if (prop === 'disabled') {
+          prop = `${section}Disabled`;
         }
-      };
 
-      var url = new URL(window.location);
-      if (url.searchParams.has('options')) {
-        options = JSON.parse(url.searchParams.get('options'));
-      }
-
-      console.log(JSON.stringify(options, null, 2));
-
-      Object.keys(options).forEach(function(section) {
-        Object.keys(options[section]).forEach(function(prop) {
-          const val = options[section][prop];
-
-          if (prop === 'disabled') {
-            prop = `${section}Disabled`;
-          }
-
-          if (typeof val === 'boolean') {
-            document.getElementById(prop).checked = val; 
-          }
-          if (typeof val === 'number') {
-            document.getElementById(prop).value = val; 
-          }
-        });
+        if (typeof val === 'boolean') {
+          document.getElementById(prop).checked = val;
+        }
+        if (typeof val === 'number') {
+          document.getElementById(prop).value = val;
+        }
       });
+    });
 
-      document.getElementById('options').querySelectorAll('input').forEach(function(opt) {
-        opt.addEventListener('change', function() {
-          if (this.type === 'checkbox') {
-            const param = this.id.endsWith('Disabled') ? 'disabled' : this.id;
+    document
+    .getElementById('options')
+    .querySelectorAll('input')
+    .forEach(function (opt) {
+      opt.addEventListener('change', function () {
+        if (this.type === 'checkbox') {
+          const param = this.id.endsWith('Disabled')
+          ? 'disabled'
+          : this.id;
 
-            options[this.getAttribute('data-section')][param] = this.checked;
-          } else {
-            options[this.getAttribute('data-section')][this.id] = parseFloat(this.value);
-          }
-          console.log(options);
-        });
+          options[this.getAttribute('data-section')][param] =
+          this.checked;
+        } else {
+          options[this.getAttribute('data-section')][this.id] =
+          parseFloat(this.value);
+        }
+        console.log(options);
       });
+    });
 
-      document.getElementById('reload').addEventListener('click', function() {
-        url.searchParams.set('options', JSON.stringify(options));
+    document
+    .getElementById('reload')
+    .addEventListener('click', function () {
+      url.searchParams.set('options', JSON.stringify(options));
 
-        window.location = url.href;
-      })
+      window.location = url.href;
+    });
 
-      window.addEventListener('orientationchange', function() {
-        var el = document.createElement('li');
-        var message = (new Date).toTimeString().split(' ')[0] + ' ' + window.orientation;
-        message += (screen && screen.orientation ? ' ' + screen.orientation.type + ' ' + screen.orientation.angle : '');
-        el.textContent = message;
-        console.log(message);
-        document.getElementById('log').appendChild(el);
-      });
+    window.addEventListener('orientationchange', function () {
+      var el = document.createElement('li');
+      var message =
+      new Date().toTimeString().split(' ')[0] + ' ' + window.orientation;
+      message +=
+      screen && screen.orientation
+      ? ' ' + screen.orientation.type + ' ' + screen.orientation.angle
+      : '';
+      el.textContent = message;
+      console.log(message);
+      document.getElementById('log').appendChild(el);
+    });
 
-      var testPlayer = window.testPlayer = videojs('videojs-mobile-ui-player');
-      testPlayer.endscreen = function() {};
-      testPlayer.mobileUi(options);
-    }(window, window.videojs));
-  </script>
+    var testPlayer = (window.testPlayer = videojs(
+      'videojs-mobile-ui-player'
+      ));
+    testPlayer.endscreen = function () {};
+    testPlayer.mobileUi(options);
+  })(window, window.videojs);
+</script>
 </body>
 </html>

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -114,7 +114,7 @@ const onPlayerReady = (player, options) => {
       if (player.paused() === false) {
         player.requestFullscreen();
         if ((options.fullscreen.lockOnRotate || options.fullscreen.alwaysLockToLandscape) &&
-          screen.orientation && screen.orientation.lock) {
+            screen.orientation && screen.orientation.lock) {
           screen.orientation.lock('landscape').then(() => {
             locked = true;
           }).catch((e) => {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -9,7 +9,7 @@ const defaults = {
     enterOnRotate: true,
     exitOnRotate: true,
     lockOnRotate: true,
-    alwaysLockToLandscape: false,
+    lockToLandscapeOnEnter: false,
     iOS: false,
     disabled: false
   },
@@ -113,7 +113,7 @@ const onPlayerReady = (player, options) => {
     if (currentOrientation === 'landscape' && options.fullscreen.enterOnRotate) {
       if (player.paused() === false) {
         player.requestFullscreen();
-        if ((options.fullscreen.lockOnRotate || options.fullscreen.alwaysLockToLandscape) &&
+        if ((options.fullscreen.lockOnRotate || options.fullscreen.lockToLandscapeOnEnter) &&
             screen.orientation && screen.orientation.lock) {
           screen.orientation.lock('landscape').then(() => {
             locked = true;
@@ -147,7 +147,7 @@ const onPlayerReady = (player, options) => {
   }
 
   player.on('fullscreenchange', _ => {
-    if (player.isFullscreen() && options.fullscreen.alwaysLockToLandscape && getOrientation() === 'portrait') {
+    if (player.isFullscreen() && options.fullscreen.lockToLandscapeOnEnter && getOrientation() === 'portrait') {
       screen.orientation.lock('landscape').then(()=>{
         locked = true;
       }).catch((e) => {
@@ -188,7 +188,7 @@ const onPlayerReady = (player, options) => {
  * @param    {boolean} [options.fullscreen.lockOnRotate=true]
  *           Whether to lock orientation when rotating to landscape
  *           Unlocked when exiting fullscreen or on 'ended
- * @param    {boolean} [options.fullscreen.alwaysLockToLandscape=false]
+ * @param    {boolean} [options.fullscreen.lockToLandscapeOnEnter=false]
  *           Whether to always lock orientation to landscape on fullscreen mode
  *           Unlocked when exiting fullscreen or on 'ended'
  * @param    {boolean} [options.fullscreen.iOS=false]

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -68,7 +68,7 @@ const onPlayerReady = (player, options) => {
   if (options.fullscreen.iOS) {
     videojs.log.warn('videojs-mobile-ui: `fullscreen.iOS` is deprecated. Use Video.js option `preferFullWindow` instead.');
     if (videojs.browser.IS_IOS && videojs.browser.IOS_VERSION > 9 &&
-      !player.el_.ownerDocument.querySelector('.bc-iframe')) {
+        !player.el_.ownerDocument.querySelector('.bc-iframe')) {
       player.tech_.el_.setAttribute('playsinline', 'playsinline');
       player.tech_.supportsFullScreen = function() {
         return false;


### PR DESCRIPTION
solves #28

```js
    player.mobileUi({
      fullscreen: {
        enterOnRotate: true,
        exitOnRotate: true,
        lockOnRotate: true,
        alwaysLockToLandscape: true,
        iOS: false,
        disabled: false,
      },
      touchControls: {
        seekSeconds: 10,
        tapTimeout: 300,
        disableOnEnd: false,
        disabled: false,
      },
    });

    player.on('play', () => {
      if (!player.isFullscreen()) {
        player.requestFullscreen()
      }
    })

```

and the fullscreen mode switches to landscape when the user taps the fullscreen icon. Since a lot of video players in the market including YouTube video player switches to landscape mode and locks in it when the user taps a fullscreen button, this feature will mimick the youtube experience.

Also, README and index.html are updated with new options including the `disabled` option which I found that you haven't mentioned in the docs.

- [x] `npm run lint` passed
- [x] `npm run test` passed with all 12 tests as SUCCESS
