### PR TITLE
fix: Hide overlay during ad playback

### DIFF
--- a/src/plugin.css
+++ b/src/plugin.css
@@ -16,7 +16,7 @@
 
 .video-js.vjs-mobile-ui {
 
-  &.vjs-has-started .vjs-touch-overlay {
+  &.vjs-has-started:not(.vjs-ad-playing) .vjs-touch-overlay {
     position: absolute;
     pointer-events: auto;
     top: 0;


### PR DESCRIPTION
Some ad integrations re-use the video element, the skip buttons shouldn't be functional during ad playback. Disables the whole overlay as even the play button could conflict with click through.

This isn't relevant for other integrations, such as IMA, which place a new element on top of the playback tech and the overlay.