### PR TITLE
feat: replace global with globalThis

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "videojs-mobile-ui",
       "version": "1.1.1",
       "license": "MIT",
-      "dependencies": {
-        "global": "^4.4.0"
-      },
       "devDependencies": {
         "@babel/runtime": "^7.14.0",
         "@videojs/generator-helpers": "~3.2.0",
@@ -4882,7 +4879,8 @@
     "node_modules/dom-walk": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
-      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
+      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==",
+      "dev": true
     },
     "node_modules/domelementtype": {
       "version": "2.3.0",
@@ -6864,6 +6862,7 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
       "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
+      "dev": true,
       "dependencies": {
         "min-document": "^2.19.0",
         "process": "^0.11.10"
@@ -10231,6 +10230,7 @@
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
       "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+      "dev": true,
       "dependencies": {
         "dom-walk": "^0.1.0"
       }
@@ -11621,6 +11621,7 @@
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+      "dev": true,
       "engines": {
         "node": ">= 0.6.0"
       }
@@ -18622,7 +18623,8 @@
     "dom-walk": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
-      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
+      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==",
+      "dev": true
     },
     "domelementtype": {
       "version": "2.3.0",
@@ -20112,6 +20114,7 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
       "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
+      "dev": true,
       "requires": {
         "min-document": "^2.19.0",
         "process": "^0.11.10"
@@ -22674,6 +22677,7 @@
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
       "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+      "dev": true,
       "requires": {
         "dom-walk": "^0.1.0"
       }
@@ -23691,7 +23695,8 @@
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+      "dev": true
     },
     "process-nextick-args": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -67,9 +67,6 @@
     "*.js": "vjsstandard --fix",
     "README.md": "doctoc --notitle"
   },
-  "dependencies": {
-    "global": "^4.4.0"
-  },
   "peerDependencies": {
     "video.js": "^8"
   },

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,7 +1,6 @@
 import videojs from 'video.js';
 import {version as VERSION} from '../package.json';
 import './touchOverlay.js';
-import window from 'global/window';
 
 // Default options for the plugin.
 const defaults = {
@@ -20,7 +19,7 @@ const defaults = {
   }
 };
 
-const screen = window.screen;
+const screen = globalThis.screen;
 
 /**
  * Gets 'portrait' or 'lanscape' from the two orientation APIs
@@ -38,8 +37,8 @@ const getOrientation = () => {
   }
 
   // iOS only supports window.orientation
-  if (typeof window.orientation === 'number') {
-    if (window.orientation === 0 || window.orientation === 180) {
+  if (typeof globalThis.orientation === 'number') {
+    if (globalThis.orientation === 0 || globalThis.orientation === 180) {
       return 'portrait';
     }
     return 'landscape';
@@ -103,10 +102,10 @@ const onPlayerReady = (player, options) => {
 
   if (options.fullscreen.enterOnRotate || options.fullscreen.exitOnRotate) {
     if (videojs.browser.IS_IOS) {
-      window.addEventListener('orientationchange', rotationHandler);
+      globalThis.addEventListener('orientationchange', rotationHandler);
 
       player.on('dispose', () => {
-        window.removeEventListener('orientationchange', rotationHandler);
+        globalThis.removeEventListener('orientationchange', rotationHandler);
       });
     } else if (screen.orientation) {
       // addEventListener('orientationchange') is not a user interaction on Android

--- a/src/touchOverlay.js
+++ b/src/touchOverlay.js
@@ -4,7 +4,6 @@
  */
 
 import videojs from 'video.js';
-import window from 'global/window';
 
 const Component = videojs.getComponent('Component');
 const dom = videojs.dom || videojs;
@@ -80,7 +79,7 @@ class TouchOverlay extends Component {
       // Remove and readd class to trigger animation
       this.setAttribute('data-skip-text', `${increment} ${this.localize('seconds')}`);
       this.removeClass('skip');
-      window.requestAnimationFrame(() => {
+      globalThis.requestAnimationFrame(() => {
         this.addClass('skip');
       });
     }, this.tapTimeout);

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -1,6 +1,3 @@
-import document from 'global/document';
-import window from 'global/window';
-
 import QUnit from 'qunit';
 import sinon from 'sinon';
 import videojs from 'video.js';
@@ -26,8 +23,8 @@ QUnit.module('videojs-mobile-ui', {
     // with the actual timer methods!
     this.clock = sinon.useFakeTimers();
 
-    this.fixture = document.getElementById('qunit-fixture');
-    this.video = document.createElement('video');
+    this.fixture = globalThis.getElementById('qunit-fixture');
+    this.video = globalThis.createElement('video');
     this.fixture.appendChild(this.video);
     this.player = videojs(this.video);
   },
@@ -89,8 +86,8 @@ QUnit.test('iOS event listeners', function(assert) {
     IS_ANDROID: false
   });
 
-  const addSpy = sinon.spy(window, 'addEventListener');
-  const removeSpy = sinon.spy(window, 'removeEventListener');
+  const addSpy = sinon.spy(globalThis, 'addEventListener');
+  const removeSpy = sinon.spy(globalThis, 'removeEventListener');
 
   this.player.mobileUi({ forceForTesting: true });
 
@@ -118,7 +115,7 @@ QUnit.test('iOS event listeners', function(assert) {
   videojs.browser = oldBrowser;
 });
 
-const testOrSkip = (window.screen && window.screen.orientation) ? 'test' : 'skip';
+const testOrSkip = (globalThis.screen && globalThis.screen.orientation) ? 'test' : 'skip';
 
 QUnit[testOrSkip]('Android event listeners', function(assert) {
 
@@ -134,7 +131,7 @@ QUnit[testOrSkip]('Android event listeners', function(assert) {
   this.clock.tick(1);
 
   assert.strictEqual(
-    typeof window.screen.orientation.onchange,
+    typeof globalThis.screen.orientation.onchange,
     'function',
     'screen.orientation.onchange is used for android'
   );
@@ -144,7 +141,7 @@ QUnit[testOrSkip]('Android event listeners', function(assert) {
   this.clock.tick(1);
 
   assert.strictEqual(
-    window.screen.orientation.onchange,
+    globalThis.screen.orientation.onchange,
     null,
     'screen.orientation.onchange is removed after dispose'
   );
@@ -171,7 +168,7 @@ QUnit[testOrSkip]('Android event listeners skipped if disabled', function(assert
   this.clock.tick(1);
 
   assert.notStrictEqual(
-    typeof window.screen.orientation.onchange,
+    typeof globalThis.screen.orientation.onchange,
     'function',
     'screen.orientation.onchange skipped for android'
   );


### PR DESCRIPTION
`globalThis` references with compatibilities:
- https://v8.dev/features/globalthis
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis

It's introduced from Node 12 (this plugin is Node >= 14) and it's the unified way to access the "global" object.

This has the benefit of making code more cross-platform and more consistent.

Old
- window.foo; // Browser
- self.foo; // Web Worker
- global.foo; // Node.js

New
- globalThis.foo;
---
Currently `globalThis` need to be pollyfilled in Karma context (tests fails).
I did these tries but didn't work:
1) `test` directory
    ```js
    // /test/polyfill-globalthis.js
    (function() {
      if (typeof globalThis === 'undefined') {
        globalThis = (function() {
          if (typeof self !== 'undefined') { return self; }
          if (typeof window !== 'undefined') { return window; }
          if (typeof global !== 'undefined') { return global; }
          throw new Error('Unable to locate global object');
        })();
      }
    })();
    ```
    
    ```diff
    // /test/karma.config.js
        files: [
    +     'test/polyfill-globalthis.js',
          'node_modules/video.js/dist/video-js.css',
          'dist/videojs-mobile-ui.css',
    
          'node_modules/sinon/pkg/sinon.js',
          'node_modules/video.js/dist/video.js',
          'test/dist/bundle.js'
        ],
    ```

2) `scripts` directory
    ```js
    // /scripts/polyfill-globalthis.js
    (function() {
      if (typeof globalThis === 'undefined') {
        globalThis = (function() {
          if (typeof self !== 'undefined') { return self; }
          if (typeof window !== 'undefined') { return window; }
          if (typeof global !== 'undefined') { return global; }
          throw new Error('Unable to locate global object');
        })();
      }
    })();
    ```

    ```diff
    // /scripts/karma.config.js
    -  const options = {};
    +  const options = {
    +    files: [
    +      'scripts/polyfill-globalthis.js',
    +      'node_modules/video.js/dist/video-js.css',
    +      'dist/*.css',
    +      'node_modules/sinon/pkg/sinon.js',
    +      'node_modules/video.js/dist/video.js',
    +      'test/dist/bundle.js'
    +    ]
    +  };
    ```

Alternative to #186